### PR TITLE
fix(cloudinary): fix for no transforms, version parsing

### DIFF
--- a/src/transformers/cloudinary.test.ts
+++ b/src/transformers/cloudinary.test.ts
@@ -5,29 +5,89 @@ import { CloudinaryParams, parse, transform } from "./cloudinary.ts";
 const img =
   "https://res.cloudinary.com/demo/image/upload/c_lfill,w_800,h_550,f_auto/dog.webp";
 
-Deno.test("cloudinary parser", () => {
-  const parsed = parse(img);
-  const expected: ParsedUrl<CloudinaryParams> = {
-    base: "https://res.cloudinary.com/demo/image/upload/c_lfill/dog",
-    cdn: "cloudinary",
-    format: "webp",
-    width: 800,
-    height: 550,
-    params: {
-      assetType: "image",
-      cloudName: "demo",
-      deliveryType: "upload",
+const imgNoTransforms = "https://res.cloudinary.com/demo/image/upload/dog.jpg";
+
+const imgWithPath =
+  "https://res.cloudinary.com/demo/image/upload/b_rgb:FFFFFF,c_fill,dpr_2.0,f_auto,g_auto,h_600,q_auto,w_600/v1/Product%20gallery%20demo/New%20Demo%20Pages/Tshirt/tshirt1";
+
+Deno.test("cloudinary parser", async (t) => {
+  await t.step("parses a URL", () => {
+    const parsed = parse(img);
+    const expected: ParsedUrl<CloudinaryParams> = {
+      base: "https://res.cloudinary.com/demo/image/upload/c_lfill/dog",
+      cdn: "cloudinary",
       format: "webp",
-      host: "res.cloudinary.com",
-      id: "dog",
-      signature: undefined,
-      transformations: {
-        c: "lfill",
+      width: 800,
+      height: 550,
+      params: {
+        assetType: "image",
+        cloudName: "demo",
+        deliveryType: "upload",
+        format: "webp",
+        host: "res.cloudinary.com",
+        id: "dog",
+        signature: undefined,
+        transformations: {
+          c: "lfill",
+        },
+        version: undefined,
       },
-      version: undefined,
-    },
-  };
-  assertEquals(parsed, expected);
+    };
+    assertEquals(parsed, expected);
+  });
+
+  await t.step("parses a URL without transforms", () => {
+    const parsed = parse(imgNoTransforms);
+    const expected: ParsedUrl<CloudinaryParams> = {
+      base: "https://res.cloudinary.com/demo/image/upload/dog",
+      cdn: "cloudinary",
+      format: "jpg",
+      width: undefined,
+      height: undefined,
+      params: {
+        assetType: "image",
+        cloudName: "demo",
+        deliveryType: "upload",
+        format: "jpg",
+        host: "res.cloudinary.com",
+        id: "dog",
+        signature: undefined,
+        transformations: {},
+        version: undefined,
+      },
+    };
+    assertEquals(parsed, expected);
+  });
+
+  await t.step("parses a URL with version and folder path", () => {
+    const parsed = parse(imgWithPath);
+    const expected: ParsedUrl<CloudinaryParams> = {
+      base:
+        "https://res.cloudinary.com/demo/image/upload/b_rgb:FFFFFF,c_fill,dpr_2.0,g_auto,q_auto/v1/Product%20gallery%20demo/New%20Demo%20Pages/Tshirt/tshirt1",
+      cdn: "cloudinary",
+      format: undefined,
+      width: 600,
+      height: 600,
+      params: {
+        assetType: "image",
+        cloudName: "demo",
+        deliveryType: "upload",
+        format: undefined,
+        host: "res.cloudinary.com",
+        id: "Product%20gallery%20demo/New%20Demo%20Pages/Tshirt/tshirt1",
+        signature: undefined,
+        transformations: {
+          b: "rgb:FFFFFF",
+          c: "fill",
+          dpr: "2.0",
+          g: "auto",
+          q: "auto",
+        },
+        version: "v1",
+      },
+    };
+    assertEquals(parsed, expected);
+  });
 });
 
 Deno.test("cloudinary transformer", async (t) => {
@@ -52,6 +112,30 @@ Deno.test("cloudinary transformer", async (t) => {
     assertEquals(
       result?.toString(),
       "https://res.cloudinary.com/demo/image/upload/c_lfill,w_101,h_200,f_auto/dog",
+    );
+  });
+
+  await t.step("transforms a URL without parsed transforms", () => {
+    const result = transform({
+      url: imgNoTransforms,
+      width: 100,
+      height: 200,
+    });
+    assertEquals(
+      result?.toString(),
+      "https://res.cloudinary.com/demo/image/upload/w_100,h_200,f_auto/dog",
+    );
+  });
+
+  await t.step("transforms a URL with path and version", () => {
+    const result = transform({
+      url: imgWithPath,
+      width: 100,
+      height: 200,
+    });
+    assertEquals(
+      result?.toString(),
+      "https://res.cloudinary.com/demo/image/upload/b_rgb:FFFFFF,c_fill,dpr_2.0,g_auto,q_auto,w_100,h_200,f_auto/v1/Product%20gallery%20demo/New%20Demo%20Pages/Tshirt/tshirt1",
     );
   });
 });

--- a/src/transformers/cloudinary.ts
+++ b/src/transformers/cloudinary.ts
@@ -8,10 +8,13 @@ import { roundIfNumeric } from "../utils.ts";
 
 // Thanks Colby!
 const cloudinaryRegex =
-  /https?:\/\/(?<host>[^\/]+)\/(?<cloudName>[^\/]+)\/(?<assetType>image|video|raw)\/(?<deliveryType>upload|fetch|private|authenticated|sprite|facebook|twitter|youtube|vimeo)\/?(?<signature>s\-\-[a-zA-Z0-9]+\-\-)?\/?(?<transformations>(?:[^_\/]+_[^,\/]+,?)*)?\/(?<version>v\d+|\w{1,2}\/)?(?<id>[^\.^\s]+)\.?(?<format>[a-zA-Z]+$)?$/g;
+  /https?:\/\/(?<host>[^\/]+)\/(?<cloudName>[^\/]+)\/(?<assetType>image|video|raw)\/(?<deliveryType>upload|fetch|private|authenticated|sprite|facebook|twitter|youtube|vimeo)\/?(?<signature>s\-\-[a-zA-Z0-9]+\-\-)?\/?(?<transformations>(?:[^_\/]+_[^,\/]+,?)*)?\/(?:(?<version>v\d+)\/)?(?<id>[^\.^\s]+)\.?(?<format>[a-zA-Z]+$)?$/g;
 
-const parseTransforms = (transformations: string) =>
-  Object.fromEntries(transformations.split(",").map((t) => t.split("_")));
+const parseTransforms = (transformations: string) => {
+  return transformations
+    ? Object.fromEntries(transformations.split(",").map((t) => t.split("_")))
+    : {};
+};
 
 const formatUrl = (
   {


### PR DESCRIPTION
Fixes for:
1. When a given URL has no transforms, `parseTransforms` has failed. This is a common case: if you upload an image to Cloudinary, apply no transforms and simply copy the URL, it has no transforms.
2. If a version is included in the url (e.g.`v176873436`), the parsed image id included a redundant slash as prefix, due to a regex issue. I've modified the regex part `(?<version>v\d+|\w{1,2}\/)?` to `(?:(?<version>v\d+)\/)?` as I didn't find any mention of alphanumeric versions (not sure if this was the intent). This also prevent some possible folder names (e.g. "ab") from being parsed as the version.