### PR TITLE
feat!: transformers may return URLs as strings

### DIFF
--- a/src/transformers/cloudinary.ts
+++ b/src/transformers/cloudinary.ts
@@ -113,7 +113,7 @@ export const generate: UrlGenerator<CloudinaryParams> = (
 
   // Default crop to fill without upscaling
   props.transformations.c ||= "lfill";
-  return new URL(formatUrl(props));
+  return formatUrl(props);
 };
 
 export const transform: UrlTransformer = (

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,7 @@ export interface UrlGeneratorOptions<TParams = Record<string, string>> {
 }
 
 export interface UrlGenerator<TParams = Record<string, string>> {
-  (options: UrlGeneratorOptions<TParams>): URL;
+  (options: UrlGeneratorOptions<TParams>): URL | string;
 }
 
 export interface ParsedUrl<TParams = Record<string, string>> {
@@ -43,7 +43,7 @@ export interface ParsedUrl<TParams = Record<string, string>> {
  * Parse an image URL into its components
  */
 export interface UrlTransformer {
-  (options: UrlTransformerOptions): URL | undefined;
+  (options: UrlTransformerOptions): string | URL | undefined;
 }
 
 export interface UrlParser<


### PR DESCRIPTION
BREAKING CHANGE

URL transformers may return a string instead of a URL. This allows us to add support for relative URLs in future. 