### PR TITLE
Set enlarge default to 0 for KeyCDN

### DIFF
--- a/src/transformers/keycdn.test.ts
+++ b/src/transformers/keycdn.test.ts
@@ -8,6 +8,7 @@ const imgNoTransforms = "https://ip.keycdn.com/example.jpg";
 const imgWithHeightWidthFormat =
   "https://ip.keycdn.com/example.jpg?width=500&height=700&format=png";
 const imgWithQuality = "https://ip.keycdn.com/example.jpg?quality=30";
+const imgOverrideEnlarge = "https://abc.kxcdn.com/example.jpg?enlarge=1";
 
 Deno.test("keycdn", async (t) => {
   await t.step("should overwrite format", () => {
@@ -19,7 +20,7 @@ Deno.test("keycdn", async (t) => {
     });
     assertEquals(
       result?.toString(),
-      "https://ip.keycdn.com/example.jpg?width=200&height=200",
+      "https://ip.keycdn.com/example.jpg?width=200&height=200&enlarge=0",
     );
   });
 
@@ -33,7 +34,19 @@ Deno.test("keycdn", async (t) => {
     });
     assertEquals(
       result?.toString(),
-      "https://ip.keycdn.com/example.jpg?width=200&height=200&format=png",
+      "https://ip.keycdn.com/example.jpg?width=200&height=200&format=png&enlarge=0",
+    );
+  });
+
+  await t.step("should not override and match keycdn for kxcdn domain", () => {
+    const result = transform({
+      url: imgOverrideEnlarge,
+      width: 400,
+      height: 600,
+    });
+    assertEquals(
+      result?.toString(),
+      "https://abc.kxcdn.com/example.jpg?enlarge=1&width=400&height=600",
     );
   });
 

--- a/src/transformers/keycdn.ts
+++ b/src/transformers/keycdn.ts
@@ -1,5 +1,9 @@
 import { UrlParser, UrlTransformer } from "../types.ts";
-import { getNumericParam, setParamIfDefined } from "../utils.ts";
+import {
+  getNumericParam,
+  setParamIfDefined,
+  setParamIfUndefined,
+} from "../utils.ts";
 
 export interface KeyCDNParams {
   quality?: number;
@@ -31,5 +35,6 @@ export const transform: UrlTransformer = (
   setParamIfDefined(url, "height", height, true, true);
   setParamIfDefined(url, "format", format, true);
   setParamIfDefined(url, "quality", getNumericParam(url, "quality"), true);
+  setParamIfUndefined(url, "enlarge", 0);
   return url;
 };


### PR DESCRIPTION
Based on this comment (https://github.com/ascorbic/unpic/pull/43#issuecomment-1495491106) tiny PR with enlarge set to zero so it doesn't upscale on the CDN's side. Doing some research it seems the crop actually defaults to smart already, so that was all good.