### PR TITLE
fix: not delete existing format (Directus)

### DIFF
--- a/src/transformers/directus.ts
+++ b/src/transformers/directus.ts
@@ -58,7 +58,7 @@ export const transform: UrlTransformer = (
   const url = new URL(originalUrl);
   setParamIfDefined(url, "width", width, true, true);
   setParamIfDefined(url, "height", height, true, true);
-  setParamIfDefined(url, "format", format, true);
+  setParamIfDefined(url, "format", format);
   setParamIfDefined(url, "quality", getNumericParam(url, "quality"), true);
   return url;
 };


### PR DESCRIPTION
Remove the `deleteExisting` on format, right now is true and if you pass a format is deleted from the URL, but must be present in order to optimize the image