### PR TITLE
adding caisy cms domain

### DIFF
--- a/data/domains.json
+++ b/data/domains.json
@@ -7,5 +7,6 @@
   "images.unsplash.com": "imgix",
   "cdn.shopify.com": "shopify",
   "s7d1.scene7.com": "scene7",
-  "ip.keycdn.com": "keycdn"
+  "ip.keycdn.com": "keycdn",
+  "assets.caisy.io": "bunny"
 }


### PR DESCRIPTION
Firstly many thanks to all the maintainers and contributors of unpic!

With this PR I am adding caisy the headless CMS to domains with bunny as CDN 

CMS Website: https://caisy.io

Example image:
https://assets.caisy.io/assets/24f83c2f-4d07-4666-84ca-420f9ab91dec/4c3d9a1f-0ed3-4186-88f1-c38ddc23258a/b94cf487-9519-4f5b-a9ae-9126048dcb8cContentBlocks.png?width=1920