### PR TITLE
fix: correctly detect relative next.js URLs

### DIFF
--- a/src/transform.test.ts
+++ b/src/transform.test.ts
@@ -58,6 +58,18 @@ Deno.test("delegation", async (t) => {
     );
   });
 
+  await t.step("should not delegate a local URL", () => {
+    const result = transformUrl({
+      url: "/_next/static/image.png",
+      width: 200,
+      height: 100,
+    });
+    assertEquals(
+      result?.toString(),
+      "/_next/image?url=%2F_next%2Fstatic%2Fimage.png&w=200&q=75",
+    );
+  });
+
   await t.step(
     "should not delegate an image CDN URL if recursion is disabled",
     () => {

--- a/src/transformers/vercel.ts
+++ b/src/transformers/vercel.ts
@@ -27,7 +27,7 @@ export const parse: UrlParser = (
 };
 
 export const delegateUrl: ShouldDelegateUrl = (url) => {
-  const parsed = new URL(url);
+  const parsed = new URL(url, "http://n");
   const source = parsed.searchParams.get("url");
   if (!source || !source.startsWith("http")) {
     return false;


### PR DESCRIPTION
Local images were causing errors when detecting next.js. This PR ensures relative URLs are handled.