### PR TITLE
Better support for Cloudinary fetch urls

### DIFF
--- a/src/transformers/cloudinary.test.ts
+++ b/src/transformers/cloudinary.test.ts
@@ -7,6 +7,8 @@ const img =
 
 const imgNoTransforms = "https://res.cloudinary.com/demo/image/upload/dog.jpg";
 
+const imgFetchNoTransforms = "https://res.cloudinary.com/demo/image/fetch/https://mydomain.com/images/logo.jpg";
+
 const imgWithPath =
   "https://res.cloudinary.com/demo/image/upload/b_rgb:FFFFFF,c_fill,dpr_2.0,f_auto,g_auto,h_600,q_auto,w_600/v1/Product%20gallery%20demo/New%20Demo%20Pages/Tshirt/tshirt1";
 
@@ -56,6 +58,29 @@ Deno.test("cloudinary parser", async (t) => {
         format: "jpg",
         host: "res.cloudinary.com",
         id: "dog",
+        signature: undefined,
+        transformations: {},
+        version: undefined,
+      },
+    };
+    assertEquals(parsed, expected);
+  });
+
+  await t.step("parses a fetch URL without transforms", () => {
+    const parsed = parse(imgFetchNoTransforms);
+    const expected: ParsedUrl<CloudinaryParams> = {
+      base: "https://res.cloudinary.com/demo/image/fetch/https://mydomain.com/images/logo",
+      cdn: "cloudinary",
+      format: "jpg",
+      width: undefined,
+      height: undefined,
+      params: {
+        assetType: "image",
+        cloudName: "demo",
+        deliveryType: "fetch",
+        format: "jpg",
+        host: "res.cloudinary.com",
+        id: "https://mydomain.com/images/logo.jpg",
         signature: undefined,
         transformations: {},
         version: undefined,
@@ -179,6 +204,18 @@ Deno.test("cloudinary transformer", async (t) => {
     assertEquals(
       result?.toString(),
       "https://res.cloudinary.com/demo/image/upload/w_100,h_200,c_lfill,f_auto/dog",
+    );
+  });
+
+    await t.step("transforms a fetch URL without parsed transforms", () => {
+    const result = transform({
+      url: imgFetchNoTransforms,
+      width: 100,
+      height: 200,
+    });
+    assertEquals(
+      result?.toString(),
+      "https://res.cloudinary.com/demo/image/fetch/w_100,h_200,c_lfill,f_auto/https://mydomain.com/images/logo.jpg"
     );
   });
 


### PR DESCRIPTION
The `fetch` version of my Cloudinary url wasn't working. This fixes it.

Example URL that works now but didn't before:

`https://res.cloudinary.com/erikras/image/fetch/https://erikras.com/images/solid-for-react-developers-miami.jpg`