### PR TITLE
fix(builder.io): force sharp to ensure correct fit behaviour

### DIFF
--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -23,11 +23,6 @@ Deno.test("E2E tests", async (t) => {
       assertEquals(width, 100);
     });
 
-    // Builder.io handles crop incorrectly at the moment
-    if (cdn === "builder.io") {
-      continue;
-    }
-
     await t.step(`${name} returns requested aspect ratio`, async () => {
       const image = transformUrl({
         url,

--- a/src/transformers/builder.test.ts
+++ b/src/transformers/builder.test.ts
@@ -14,7 +14,7 @@ Deno.test("builder.io", async (t) => {
     });
     assertEquals(
       result?.toString(),
-      "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F462d29d57dda42cb9e26441501db535f?width=200&height=100&fit=cover",
+      "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F462d29d57dda42cb9e26441501db535f?width=200&height=100&fit=cover&sharp=true",
     );
   });
   await t.step("should not set height if not provided", () => {
@@ -42,17 +42,17 @@ Deno.test("builder.io", async (t) => {
     });
     assertEquals(
       result?.toString(),
-      "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F462d29d57dda42cb9e26441501db535f?width=201&height=100&fit=cover",
+      "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F462d29d57dda42cb9e26441501db535f?width=201&height=100&fit=cover&sharp=true",
     );
   });
 
   await t.step("should not set fit=cover if another value exists", () => {
     const url = new URL(img);
     url.searchParams.set("fit", "inside");
-    const result = transform({ url, width: 200 });
+    const result = transform({ url, width: 200, height: 100 });
     assertEquals(
       result?.toString(),
-      "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F462d29d57dda42cb9e26441501db535f?fit=inside&width=200",
+      "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F462d29d57dda42cb9e26441501db535f?fit=inside&width=200&height=100&sharp=true",
     );
   });
 });

--- a/src/transformers/builder.ts
+++ b/src/transformers/builder.ts
@@ -35,6 +35,7 @@ export const transform: UrlTransformer = (
   setParamIfDefined(url, "format", format);
   if (width && height) {
     setParamIfUndefined(url, "fit", "cover");
+    setParamIfUndefined(url, "sharp", "true");
   }
   return url;
 };


### PR DESCRIPTION
Builder.io doesn't implement `fit` unless in `sharp` mode, so this PR makes that the default