### PR TITLE
feat: add support for Cloudflare Images

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ To add a new CDN, add the following:
 - import the new source file in `src/transform.ts` and `src/parse.ts`
 - add a sample image to `examples.json` in the demo site. Run the site locally
   to see that it works.
-- ensure tests pass by installing Deno and running `deno test src`
+- ensure tests pass by installing Deno and running `deno test src --allow-net`
 
 ### Image defaults
 

--- a/data/paths.json
+++ b/data/paths.json
@@ -1,5 +1,6 @@
 {
   "/cdn-cgi/image/": "cloudflare",
+  "/cdn-cgi/imagedelivery/": "cloudflare_images",
   "/_next/image": "nextjs",
   "/_next/static": "nextjs",
   "/_vercel/image": "vercel",

--- a/demo/src/examples.json
+++ b/demo/src/examples.json
@@ -59,5 +59,9 @@
   "contentstack": [
     "Contentstack",
     "https://images.contentstack.io/v3/assets/blteae40eb499811073/bltc5064f36b5855343/59e0c41ac0eddd140d5a8e3e/owl.jpg"
+  ],
+  "cloudflare_images": [
+    "Cloudflare Images",
+    "https://100francisco.com/cdn-cgi/imagedelivery/1aS6NlIe-Sc1o3NhVvy8Qw/2ba36ba9-69f6-41b6-8ff0-2779b41df200"
   ]
 }

--- a/demo/src/examples.json
+++ b/demo/src/examples.json
@@ -48,10 +48,6 @@
     "https://s7d1.scene7.com/is/image/sample/s9?wid=500&hei=700&fmt=webp"
   ],
   "keycdn": ["KeyCDN", "https://ip.keycdn.com/example.jpg"],
-  "directus": [
-    "Directus",
-    "https://apollo.kazel.academy/assets/6d910d38-0659-49bf-80b8-fa6e0b257975"
-  ],
   "imageengine": [
     "ImageEngine",
     "https://blazing-fast-pics.cdn.imgeng.in/images/pic_1.jpg?imgeng=/w_400"

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -16,6 +16,7 @@ import { parse as keycdn } from "./transformers/keycdn.ts";
 import { parse as directus } from "./transformers/directus.ts";
 import { parse as imageengine } from "./transformers/imageengine.ts";
 import { parse as contentstack } from "./transformers/contentstack.ts";
+import { parse as cloudflareImages } from "./transformers/cloudflareimages.ts";
 import { ImageCdn, ParsedUrl, SupportedImageCdn, UrlParser } from "./types.ts";
 
 export const parsers = {
@@ -36,6 +37,7 @@ export const parsers = {
   directus,
   imageengine,
   contentstack,
+  "cloudflare_images": cloudflareImages,
 };
 
 export const cdnIsSupportedForParse = (

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -16,6 +16,7 @@ import { transform as keycdn } from "./transformers/keycdn.ts";
 import { transform as directus } from "./transformers/directus.ts";
 import { transform as imageengine } from "./transformers/imageengine.ts";
 import { transform as contentstack } from "./transformers/contentstack.ts";
+import { transform as cloudflareImages } from "./transformers/cloudflareimages.ts";
 import { ImageCdn, UrlTransformer } from "./types.ts";
 import { getCanonicalCdnForUrl } from "./canonical.ts";
 
@@ -37,6 +38,7 @@ export const getTransformer = (cdn: ImageCdn) => ({
   directus,
   imageengine,
   contentstack,
+  "cloudflare_images": cloudflareImages,
 }[cdn]);
 
 /**

--- a/src/transformers/cloudflareimages.test.ts
+++ b/src/transformers/cloudflareimages.test.ts
@@ -1,0 +1,40 @@
+import { assertEquals } from "https://deno.land/std@0.172.0/testing/asserts.ts";
+import { ParsedUrl } from "../types.ts";
+import { CloudflareImagesParams, parse, transform } from "./cloudflareimages.ts";
+
+const img =
+  "https://100francisco.com/cdn-cgi/imagedelivery/1aS6NlIe-Sc1o3NhVvy8Qw/2ba36ba9-69f6-41b6-8ff0-2779b41df200/w=128,h=128,rotate=90,f=auto";
+
+Deno.test("cloudflare images parser", () => {
+  const parsed = parse(img);
+  const expected: ParsedUrl<CloudflareImagesParams> = {
+    base: img,
+    cdn: "cloudflare_images",
+    format: "auto",
+    width: 128,
+    height: 128,
+    params: {
+      host: "100francisco.com",
+      accountHash: "1aS6NlIe-Sc1o3NhVvy8Qw",
+      imageId: "2ba36ba9-69f6-41b6-8ff0-2779b41df200",
+        transformations: {
+            rotate: "90",
+        }
+    },
+  };
+  assertEquals(parsed, expected);
+});
+
+Deno.test("cloudflare images transformer", async (t) => {
+  await t.step("transforms a URL", () => {
+    const result = transform({
+      url: img,
+      width: 100,
+      height: 200,
+    });
+    assertEquals(
+      result?.toString(),
+      "https://100francisco.com/cdn-cgi/imagedelivery/1aS6NlIe-Sc1o3NhVvy8Qw/2ba36ba9-69f6-41b6-8ff0-2779b41df200/rotate=90,w=100,h=200,f=auto,fit=cover",
+    );
+  });
+});

--- a/src/transformers/cloudflareimages.ts
+++ b/src/transformers/cloudflareimages.ts
@@ -1,0 +1,116 @@
+import {
+  UrlGenerator,
+  UrlGeneratorOptions,
+  UrlParser,
+  UrlTransformer,
+} from "../types.ts";
+import { toUrl } from "../utils.ts";
+
+const cloudflareImagesRegex =
+  /https?:\/\/(?<host>[^\/]+)\/cdn-cgi\/imagedelivery\/(?<accountHash>[^\/]+)\/(?<imageId>[^\/]+)\/*(?<transformations>[^\/]+)*$/g;
+
+const parseTransforms = (transformations: string) =>
+  Object.fromEntries(transformations?.split(",")?.map((t) => t.split("=")) ?? []);
+
+const formatUrl = (
+  {
+    host,
+    accountHash,
+    transformations = {},
+    imageId,
+  }: CloudflareImagesParams,
+): string => {
+  const transformString = Object.entries(transformations).map(
+    ([key, value]) => `${key}=${value}`,
+  ).join(",");
+
+  const pathSegments = [
+      host,
+    "cdn-cgi",
+    "imagedelivery",
+    accountHash,
+    imageId,
+    transformString,
+  ].join("/");
+  return `https://${pathSegments}`;
+};
+
+export interface CloudflareImagesParams {
+  host?: string;
+  accountHash?: string;
+  imageId?: string;
+  transformations: Record<string, string>;
+}
+export const parse: UrlParser<CloudflareImagesParams> = (
+  imageUrl,
+) => {
+  const url = toUrl(imageUrl);
+  const matches = [...url.toString().matchAll(cloudflareImagesRegex)];
+  if (!matches.length) {
+    throw new Error("Invalid Cloudflare Images URL");
+  }
+
+  const group = matches[0].groups || {};
+  const {
+    transformations: transformString,
+    ...baseParams
+  } = group;
+
+  const { w, h, f, ...transformations } = parseTransforms(
+    transformString,
+  );
+
+  return {
+    base: url.toString(),
+    width: Number(w) || undefined,
+    height: Number(h) || undefined,
+    format: f,
+    cdn: "cloudflare_images",
+    params: { ...baseParams, transformations },
+  };
+};
+
+export const generate: UrlGenerator<CloudflareImagesParams> = (
+  { base, width, height, format, params },
+) => {
+  const parsed = parse(base.toString());
+
+  const props: CloudflareImagesParams = {
+    transformations: {},
+    ...parsed.params,
+    ...params,
+  };
+
+  if (width) {
+    props.transformations.w = width?.toString();
+  }
+  if (height) {
+    props.transformations.h = height?.toString();
+  }
+  if (format) {
+    props.transformations.f = format;
+  }
+
+  props.transformations.fit ||= "cover";
+
+  return new URL(formatUrl(props));
+};
+
+export const transform: UrlTransformer = (
+  { url: originalUrl, width, height, format = "auto" },
+) => {
+  const parsed = parse(originalUrl);
+
+  if (!parsed) {
+    throw new Error("Invalid Cloudflare Images URL");
+  }
+
+  const props: UrlGeneratorOptions<CloudflareImagesParams> = {
+    ...parsed,
+    width,
+    height,
+    format,
+  };
+
+  return generate(props);
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,6 +92,7 @@ export type ImageCdn =
   | "keycdn"
   | "directus"
   | "imageengine"
-  | "contentstack";
+  | "contentstack"
+  | "cloudflare_images";
 
 export type SupportedImageCdn = ImageCdn;


### PR DESCRIPTION
This PR adds support for [Cloudflare Images](https://developers.cloudflare.com/images/cloudflare-images/) (not to be confused with [Cloudflare Image Resizing](https://developers.cloudflare.com/images/image-resizing/)

CF Images offers `Flexible Variants` ([doc](https://developers.cloudflare.com/images/cloudflare-images/transform/flexible-variants/)) as a way to dynamically resize and transform images. The base URL is:

```
https://imagedelivery.net/<ACCOUNT_HASH>/<IMAGE_ID>/w=400,sharpen=3
```

CF Images supports serving images over a [custom domain](https://developers.cloudflare.com/images/cloudflare-images/serve-images/serve-images-custom-domains/), with URL:

```
https://example.com/cdn-cgi/imagedelivery/<ACCOUNT_HASH>/<IMAGE_ID>/<VARIANT_NAME>
```

This PR implements URL parsing for the custom domain pattern as I would expect this to be the most commonly used. 

<img width="1110" alt="CleanShot 2023-07-31 at 23 03 16@2x" src="https://github.com/ascorbic/unpic/assets/2076017/c1b4b383-b13f-449e-b52b-d2e2ef1e25ca">


Resolves #12