### PR TITLE
feat: add Uploadcare support

### DIFF
--- a/data/domains.json
+++ b/data/domains.json
@@ -9,5 +9,6 @@
   "s7d1.scene7.com": "scene7",
   "ip.keycdn.com": "keycdn",
   "assets.caisy.io": "bunny",
-  "images.contentstack.io": "contentstack"
+  "images.contentstack.io": "contentstack",
+  "ucarecdn.com": "uploadcare"
 }

--- a/data/subdomains.json
+++ b/data/subdomains.json
@@ -8,5 +8,6 @@
   "kxcdn.com": "keycdn",
   "imgeng.in": "imageengine",
   "imagekit.io": "imagekit",
-  "cloudimg.io": "cloudimage"
+  "cloudimg.io": "cloudimage",
+  "ucarecdn.com": "uploadcare"
 }

--- a/demo/src/examples.json
+++ b/demo/src/examples.json
@@ -75,5 +75,9 @@
   "cloudimage": [
     "Cloudimage",
     "https://doc.cloudimg.io/sample.li/flat1.jpg?w=450&q=90"
+  ],
+  "uploadcare": [
+    "Uploadcare",
+    "https://ucarecdn.com/661bd414-064c-477a-b50f-8ffd8f66aa49/"
   ]
 }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -22,6 +22,7 @@ import { parse as ipx } from "./transformers/ipx.ts";
 import { parse as astro } from "./transformers/astro.ts";
 import { parse as netlify } from "./transformers/netlify.ts";
 import { parse as imagekit } from "./transformers/imagekit.ts";
+import { parse as uploadcare } from "./transformers/uploadcare.ts";
 import { ImageCdn, ParsedUrl, SupportedImageCdn, UrlParser } from "./types.ts";
 
 export const parsers = {
@@ -48,6 +49,7 @@ export const parsers = {
   astro,
   netlify,
   imagekit,
+  uploadcare,
 };
 
 export const cdnIsSupportedForParse = (

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -22,6 +22,7 @@ import { transform as ipx } from "./transformers/ipx.ts";
 import { transform as astro } from "./transformers/astro.ts";
 import { transform as netlify } from "./transformers/netlify.ts";
 import { transform as imagekit } from "./transformers/imagekit.ts";
+import { transform as uploadcare } from "./transformers/uploadcare.ts";
 import { ImageCdn, UrlTransformer } from "./types.ts";
 import { getCanonicalCdnForUrl } from "./canonical.ts";
 
@@ -49,6 +50,7 @@ export const getTransformer = (cdn: ImageCdn) => ({
   astro,
   netlify,
   imagekit,
+  uploadcare,
 }[cdn]);
 
 /**

--- a/src/transformers/uploadcare.test.ts
+++ b/src/transformers/uploadcare.test.ts
@@ -9,7 +9,7 @@ const img =
 const imgNoOperations = baseImage;
 
 const imgSubdomain =
-  "https://private-name.example.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/-/resize/800x550/";
+  "https://private-name.example.com/661bd414-064c-477a-b50f-8ffd8f66aa49/-/resize/800x550/";
 
 const imgWithFilename =
   "https://ucarecdn.com/661bd414-064c-477a-b50f-8ffd8f66aa49/-/resize/800x550/auto/tshirt1.jpg";
@@ -23,7 +23,7 @@ Deno.test("uploadcare parser", async (t) => {
       cdn: "uploadcare",
       params: {
         host: "ucarecdn.com",
-        uuid: "d7fe74ac-65b8-4ade-875f-ccd92759a70f",
+        uuid: "661bd414-064c-477a-b50f-8ffd8f66aa49",
         operations: {
           resize: "800x550",
           format: "auto",
@@ -41,7 +41,7 @@ Deno.test("uploadcare parser", async (t) => {
       cdn: "uploadcare",
       params: {
         host: "ucarecdn.com",
-        uuid: "d7fe74ac-65b8-4ade-875f-ccd92759a70f",
+        uuid: "661bd414-064c-477a-b50f-8ffd8f66aa49",
         operations: {
           format: "auto",
         },
@@ -55,11 +55,11 @@ Deno.test("uploadcare parser", async (t) => {
     const parsed = parse(imgSubdomain);
     const expected: ParsedUrl<UploadcareParams> = {
       base:
-        "https://private-name.example.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/-/resize/800x550/-/format/auto/",
+        "https://private-name.example.com/661bd414-064c-477a-b50f-8ffd8f66aa49/-/resize/800x550/-/format/auto/",
       cdn: "uploadcare",
       params: {
         host: "private-name.example.com",
-        uuid: "d7fe74ac-65b8-4ade-875f-ccd92759a70f",
+        uuid: "661bd414-064c-477a-b50f-8ffd8f66aa49",
         operations: {
           resize: "800x550",
           format: "auto",
@@ -78,7 +78,7 @@ Deno.test("uploadcare parser", async (t) => {
       cdn: "uploadcare",
       params: {
         host: "ucarecdn.com",
-        uuid: "d7fe74ac-65b8-4ade-875f-ccd92759a70f",
+        uuid: "661bd414-064c-477a-b50f-8ffd8f66aa49",
         operations: {
           resize: "800x550",
           format: "auto",

--- a/src/transformers/uploadcare.test.ts
+++ b/src/transformers/uploadcare.test.ts
@@ -2,9 +2,9 @@ import { assertEquals } from "https://deno.land/std@0.172.0/testing/asserts.ts";
 import { ParsedUrl } from "../types.ts";
 import { parse, transform, UploadcareParams } from "./uploadcare.ts";
 
-const baseImage = "https://ucarecdn.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/";
+const baseImage = "https://ucarecdn.com/661bd414-064c-477a-b50f-8ffd8f66aa49/";
 const img =
-  "https://ucarecdn.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/-/resize/800x550/";
+  "https://ucarecdn.com/661bd414-064c-477a-b50f-8ffd8f66aa49/-/resize/800x550/";
 
 const imgNoOperations = baseImage;
 
@@ -12,14 +12,14 @@ const imgSubdomain =
   "https://private-name.example.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/-/resize/800x550/";
 
 const imgWithFilename =
-  "https://ucarecdn.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/-/resize/800x550/auto/tshirt1.jpg";
+  "https://ucarecdn.com/661bd414-064c-477a-b50f-8ffd8f66aa49/-/resize/800x550/auto/tshirt1.jpg";
 
 Deno.test("uploadcare parser", async (t) => {
   await t.step("parses a URL", () => {
     const parsed = parse(img);
     const expected: ParsedUrl<UploadcareParams> = {
       base:
-        "https://ucarecdn.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/-/resize/800x550/-/format/auto/",
+        "https://ucarecdn.com/661bd414-064c-477a-b50f-8ffd8f66aa49/-/resize/800x550/-/format/auto/",
       cdn: "uploadcare",
       params: {
         host: "ucarecdn.com",
@@ -74,7 +74,7 @@ Deno.test("uploadcare parser", async (t) => {
     const parsed = parse(imgWithFilename);
     const expected: ParsedUrl<UploadcareParams> = {
       base:
-        "https://ucarecdn.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/-/resize/800x550/-/format/auto/tshirt1.jpg",
+        "https://ucarecdn.com/661bd414-064c-477a-b50f-8ffd8f66aa49/-/resize/800x550/-/format/auto/tshirt1.jpg",
       cdn: "uploadcare",
       params: {
         host: "ucarecdn.com",
@@ -99,7 +99,7 @@ Deno.test("uploadcare transformer", async (t) => {
     });
     assertEquals(
       result?.toString(),
-      "https://ucarecdn.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/-/resize/100x200/-/format/auto/",
+      "https://ucarecdn.com/661bd414-064c-477a-b50f-8ffd8f66aa49/-/resize/100x200/-/format/auto/",
     );
   });
 
@@ -111,7 +111,7 @@ Deno.test("uploadcare transformer", async (t) => {
     });
     assertEquals(
       result?.toString(),
-      "https://ucarecdn.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/-/resize/100.6x200.2/-/format/auto/",
+      "https://ucarecdn.com/661bd414-064c-477a-b50f-8ffd8f66aa49/-/resize/100.6x200.2/-/format/auto/",
     );
   });
 
@@ -123,7 +123,7 @@ Deno.test("uploadcare transformer", async (t) => {
     });
     assertEquals(
       result?.toString(),
-      "https://ucarecdn.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/-/format/auto/-/resize/100x200/",
+      "https://ucarecdn.com/661bd414-064c-477a-b50f-8ffd8f66aa49/-/format/auto/-/resize/100x200/",
     );
   });
 
@@ -135,7 +135,7 @@ Deno.test("uploadcare transformer", async (t) => {
     });
     assertEquals(
       result?.toString(),
-      "https://ucarecdn.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/-/resize/100x200/-/format/auto/tshirt1.jpg",
+      "https://ucarecdn.com/661bd414-064c-477a-b50f-8ffd8f66aa49/-/resize/100x200/-/format/auto/tshirt1.jpg",
     );
   });
 });

--- a/src/transformers/uploadcare.test.ts
+++ b/src/transformers/uploadcare.test.ts
@@ -1,0 +1,141 @@
+import { assertEquals } from "https://deno.land/std@0.172.0/testing/asserts.ts";
+import { ParsedUrl } from "../types.ts";
+import { parse, transform, UploadcareParams } from "./uploadcare.ts";
+
+const baseImage = "https://ucarecdn.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/";
+const img =
+  "https://ucarecdn.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/-/resize/800x550/";
+
+const imgNoOperations = baseImage;
+
+const imgSubdomain =
+  "https://private-name.example.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/-/resize/800x550/";
+
+const imgWithFilename =
+  "https://ucarecdn.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/-/resize/800x550/auto/tshirt1.jpg";
+
+Deno.test("uploadcare parser", async (t) => {
+  await t.step("parses a URL", () => {
+    const parsed = parse(img);
+    const expected: ParsedUrl<UploadcareParams> = {
+      base:
+        "https://ucarecdn.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/-/resize/800x550/-/format/auto/",
+      cdn: "uploadcare",
+      params: {
+        host: "ucarecdn.com",
+        uuid: "d7fe74ac-65b8-4ade-875f-ccd92759a70f",
+        operations: {
+          resize: "800x550",
+          format: "auto",
+        },
+        filename: undefined,
+      },
+    };
+    assertEquals(parsed, expected);
+  });
+
+  await t.step("parses a URL without operations", () => {
+    const parsed = parse(imgNoOperations);
+    const expected: ParsedUrl<UploadcareParams> = {
+      base: `${baseImage}-/format/auto/`,
+      cdn: "uploadcare",
+      params: {
+        host: "ucarecdn.com",
+        uuid: "d7fe74ac-65b8-4ade-875f-ccd92759a70f",
+        operations: {
+          format: "auto",
+        },
+        filename: undefined,
+      },
+    };
+    assertEquals(parsed, expected);
+  });
+
+  await t.step("parses a URL with custom domain", () => {
+    const parsed = parse(imgSubdomain);
+    const expected: ParsedUrl<UploadcareParams> = {
+      base:
+        "https://private-name.example.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/-/resize/800x550/-/format/auto/",
+      cdn: "uploadcare",
+      params: {
+        host: "private-name.example.com",
+        uuid: "d7fe74ac-65b8-4ade-875f-ccd92759a70f",
+        operations: {
+          resize: "800x550",
+          format: "auto",
+        },
+        filename: undefined,
+      },
+    };
+    assertEquals(parsed, expected);
+  });
+
+  await t.step("parses a URL with filename", () => {
+    const parsed = parse(imgWithFilename);
+    const expected: ParsedUrl<UploadcareParams> = {
+      base:
+        "https://ucarecdn.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/-/resize/800x550/-/format/auto/tshirt1.jpg",
+      cdn: "uploadcare",
+      params: {
+        host: "ucarecdn.com",
+        uuid: "d7fe74ac-65b8-4ade-875f-ccd92759a70f",
+        operations: {
+          resize: "800x550",
+          format: "auto",
+        },
+        filename: "tshirt1.jpg",
+      },
+    };
+    assertEquals(parsed, expected);
+  });
+});
+
+Deno.test("uploadcare transformer", async (t) => {
+  await t.step("transforms a URL", () => {
+    const result = transform({
+      url: img,
+      width: 100,
+      height: 200,
+    });
+    assertEquals(
+      result?.toString(),
+      "https://ucarecdn.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/-/resize/100x200/-/format/auto/",
+    );
+  });
+
+  await t.step("rounds non-integer values", () => {
+    const result = transform({
+      url: img,
+      width: 100.6,
+      height: 200.2,
+    });
+    assertEquals(
+      result?.toString(),
+      "https://ucarecdn.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/-/resize/100.6x200.2/-/format/auto/",
+    );
+  });
+
+  await t.step("transforms a URL without parsed transforms", () => {
+    const result = transform({
+      url: imgNoOperations,
+      width: 100,
+      height: 200,
+    });
+    assertEquals(
+      result?.toString(),
+      "https://ucarecdn.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/-/format/auto/-/resize/100x200/",
+    );
+  });
+
+  await t.step("transforms a URL with path and version", () => {
+    const result = transform({
+      url: imgWithFilename,
+      width: 100,
+      height: 200,
+    });
+    assertEquals(
+      result?.toString(),
+      "https://ucarecdn.com/d7fe74ac-65b8-4ade-875f-ccd92759a70f/-/resize/100x200/-/format/auto/tshirt1.jpg",
+    );
+  });
+});

--- a/src/transformers/uploadcare.ts
+++ b/src/transformers/uploadcare.ts
@@ -1,0 +1,411 @@
+import {
+  UrlGenerator,
+  UrlGeneratorOptions,
+  UrlParser,
+  UrlTransformer,
+} from "../types.ts";
+import { toUrl } from "../utils.ts";
+
+const uploadcareRegex = /^https?:\/\/(?<host>[^\/]+)\/(?<uuid>[^\/]+)/g;
+
+/**
+ * Taken from uploadcare/blocks
+ *
+ * @see https://github.com/uploadcare/blocks/blob/87d1048e94f05f99e1da988c86c6362522e9a3c8/utils/cdn-utils.js#L57
+ */
+export function extractFilename(cdnUrl: string) {
+  const url = new URL(cdnUrl);
+  const noOrigin = url.pathname + url.search + url.hash;
+  const urlFilenameIdx = noOrigin.lastIndexOf("http");
+  const plainFilenameIdx = noOrigin.lastIndexOf("/");
+  let filename = "";
+
+  if (urlFilenameIdx >= 0) {
+    filename = noOrigin.slice(urlFilenameIdx);
+  } else if (plainFilenameIdx >= 0) {
+    filename = noOrigin.slice(plainFilenameIdx + 1);
+  }
+
+  return filename;
+}
+
+/**
+ * Taken from uploadcare/blocks
+ *
+ * @see https://github.com/uploadcare/blocks/blob/87d1048e94f05f99e1da988c86c6362522e9a3c8/utils/cdn-utils.js#L131
+ */
+export function isFileUrl(filename: string) {
+  return filename.startsWith("http");
+}
+
+/**
+ * Taken from uploadcare/blocks
+ *
+ * @see https://github.com/uploadcare/blocks/blob/87d1048e94f05f99e1da988c86c6362522e9a3c8/utils/cdn-utils.js#L141
+ */
+export function splitFileUrl(fileUrl: string) {
+  const url = new URL(fileUrl);
+  return {
+    pathname: url.origin + url.pathname || "",
+    search: url.search || "",
+    hash: url.hash || "",
+  };
+}
+
+/**
+ * Taken from uploadcare/blocks
+ *
+ * @see https://github.com/uploadcare/blocks/blob/87d1048e94f05f99e1da988c86c6362522e9a3c8/utils/cdn-utils.js#L114
+ */
+export function trimFilename(cdnUrl: string) {
+  const url = new URL(cdnUrl);
+  const filename = extractFilename(cdnUrl);
+  const filenamePathPart = isFileUrl(filename)
+    ? splitFileUrl(filename).pathname
+    : filename;
+
+  url.pathname = url.pathname.replace(filenamePathPart, "");
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
+/**
+ * Taken from uploadcare/blocks
+ *
+ * @see https://github.com/uploadcare/blocks/blob/87d1048e94f05f99e1da988c86c6362522e9a3c8/utils/cdn-utils.js#L9C1-L24C3
+ */
+export const normalizeCdnOperation = (operation: string) => {
+  if (typeof operation !== "string" || !operation) {
+    return "";
+  }
+  let str = operation.trim();
+  if (str.startsWith("-/")) {
+    str = str.slice(2);
+  } else if (str.startsWith("/")) {
+    str = str.slice(1);
+  }
+
+  if (str.endsWith("/")) {
+    str = str.slice(0, str.length - 1);
+  }
+  return str;
+};
+
+/**
+ * Taken from uploadcare/blocks
+ *
+ * @see https://github.com/uploadcare/blocks/blob/87d1048e94f05f99e1da988c86c6362522e9a3c8/utils/cdn-utils.js#L93C1-L106C2
+ */
+export function extractOperations(cdnUrl: string) {
+  const withoutFilename = trimFilename(cdnUrl);
+  const url = new URL(withoutFilename);
+  const operationsMarker = url.pathname.indexOf("/-/");
+  if (operationsMarker === -1) {
+    return [];
+  }
+  const operationsStr = url.pathname.substring(operationsMarker);
+
+  return operationsStr
+    .split("/-/")
+    .filter(Boolean)
+    .map((operation) => normalizeCdnOperation(operation));
+}
+
+const parseOperations = (operations: Array<string>): UploadcareOperations => {
+  return operations.length
+    ? operations.reduce((acc, operation) => {
+      const [key, value] = operation.split("/");
+      return {
+        ...acc,
+        [key]: value,
+      };
+    }, {})
+    : {};
+};
+
+type NumericRange<
+  START extends number,
+  END extends number,
+  ARR extends unknown[] = [],
+  ACC extends number = never,
+> = ARR["length"] extends END ? ACC | START | END
+  : NumericRange<
+    START,
+    END,
+    [...ARR, 1],
+    ARR[START] extends undefined ? ACC : ACC | ARR["length"]
+  >;
+
+interface UploadcareOperations {
+  /**
+   * @see https://uploadcare.com/docs/transformations/image/compression/#operation-format
+   *
+   * @default "auto"
+   */
+  format?: "jpeg" | "png" | "webp" | "auto" | "preserve";
+  /**
+   * @see https://uploadcare.com/docs/transformations/image/compression/#operation-quality
+   *
+   * @default "normal"
+   */
+  quality?: "normal" | "better" | "best" | "lighter" | "lightest";
+  /**
+   * @see https://uploadcare.com/docs/transformations/image/compression/#operation-progressive
+   *
+   * @default "no"
+   */
+  progressive?: "yes" | "no";
+  /**
+   * @see https://uploadcare.com/docs/transformations/image/compression/#meta-information-control
+   *
+   * @default "all"
+   */
+  strip_meta?: "all" | "none" | "sensitive";
+  /**
+   * @see https://uploadcare.com/docs/transformations/image/resize-crop/#operation-preview
+   *
+   * @example "320x240"
+   * @returns `-/preview/:dimensions/`
+   */
+  preview?: `${number}x${number}`;
+  /**
+   * @see https://uploadcare.com/docs/transformations/image/resize-crop/#operation-resize
+   *
+   * @example "320x240", "320x" or "x240"
+   * @returns `-/resize/:one_or_two_dimensions/`
+   */
+  resize?: `${number}x${number}` | `${number}x` | `x${number}`;
+  /**
+   * @see https://uploadcare.com/docs/transformations/image/resize-crop/#operation-stretch
+   *
+   * @returns `-/stretch/:mode/`
+   */
+  stretch?: "on" | "off" | "fill";
+  /**
+   * @see https://uploadcare.com/docs/transformations/image/resize-crop/#operation-smart-resize
+   *
+   * @returns `-/smart_resize/:dimensions/`
+   */
+  smart_resize?: `${number}x${number}`;
+  /**
+   * @see https://uploadcare.com/docs/transformations/image/resize-crop/#operation-crop
+   *
+   * @returns `-/crop/:dimensions/` or `-/crop/:dimensions/:alignment/`
+   */
+  crop?:
+    | `${number}${"x" | ","}${number}`
+    | `${number}${"x" | ","}${number}${"p" | "%"}`
+    | `${number}${"p" | "%"}${"x" | ","}${number}`
+    | `${number}${"p" | "%"}${"x" | ","}${number}${"p" | "%"}`
+    | `${number}${"x" | ","}${number}/${number}${"x" | ","}${number}`
+    | `${number}${"x" | ","}${number}/${number}${"x" | ","}${number}${
+      | "p"
+      | "%"}`
+    | `${number}${"x" | ","}${number}/${number}${"p" | "%"}${
+      | "x"
+      | ","}${number}`
+    | `${number}${"x" | ","}${number}/${number}${"p" | "%"}${
+      | "x"
+      | ","}${number}${"p" | "%"}`;
+  /**
+   * @see https://uploadcare.com/docs/transformations/image/resize-crop/#operation-scale-crop
+   *
+   * @returns `-/scale_crop/:dimensions/` or `-/scale_crop/:dimensions/:alignment/
+   */
+  scale_crop?:
+    | `${number}${"x" | ","}${number}`
+    | `${number}${"x" | ","}${number}${"p" | "%"}`
+    | `${number}${"p" | "%"}${"x" | ","}${number}`
+    | `${number}${"p" | "%"}${"x" | ","}${number}${"p" | "%"}`
+    | `${number}${"x" | ","}${number}/${number}${"x" | ","}${number}`
+    | `${number}${"x" | ","}${number}/${number}${"x" | ","}${number}${
+      | "p"
+      | "%"}`
+    | `${number}${"x" | ","}${number}/${number}${"p" | "%"}${
+      | "x"
+      | ","}${number}`
+    | `${number}${"x" | ","}${number}/${number}${"p" | "%"}${
+      | "x"
+      | ","}${number}${"p" | "%"}`;
+  /**
+   * @see https://uploadcare.com/docs/transformations/image/resize-crop/#operation-border-radius
+   *
+   * @returns `-/border_radius/:radii/ or `-/border_radius/:radii/:vertical_radii/`
+   */
+  border_radius?:
+    | `${number}${"p" | "%" | ""}${"," | ""}${number}${"p" | "%" | ""}`
+    | `${number}${"p" | "%" | ""}${"," | ""}${number}${
+      | "p"
+      | "%"
+      | ""}/${number}${
+      | "p"
+      | "%"}${"," | ""}${number}${"p" | "%" | ""}`
+    | `${number}${"p" | "%" | ""}${"," | ""}${number}${
+      | "p"
+      | "%"
+      | ""}/${number}${
+      | "p"
+      | "%"}${"," | ""}${number}${"p" | "%" | ""}`;
+  /**
+   * @see https://uploadcare.com/docs/transformations/image/resize-crop/#operation-setfill
+   *
+   * @returns `-/setfill/:color/`
+   */
+  setfill?: string;
+  /**
+   * @see https://uploadcare.com/docs/transformations/image/resize-crop/#operation-zoom-objects
+   *
+   * @returns `-/zoom_objects/:zoom/`
+   */
+  zoom_objects?: NumericRange<1, 100>;
+  /**
+   * @see https://uploadcare.com/docs/transformations/image/resize-crop/#operation-autorotate
+   *
+   * @returns `-/autorotate/yes/` or `-/autorotate/no/`
+   */
+  autorotate?: "yes" | "no";
+  /**
+   * @see https://uploadcare.com/docs/transformations/image/resize-crop/#operation-autorotate
+   *
+   * @returns `-/rotate/:angle/`
+   */
+  rotate?: NumericRange<0, 359>;
+  /**
+   * @see https://uploadcare.com/docs/transformations/image/resize-crop/#operation-flip
+   *
+   * @returns `-/flip/`
+   */
+  flip?: true;
+  /**
+   * @see https://uploadcare.com/docs/transformations/image/resize-crop/#operation-mirror
+   *
+   * @returns `-/mirror/`
+   */
+  mirror?: true;
+}
+
+export interface UploadcareParams {
+  host?: string;
+  uuid?: string;
+  operations?: UploadcareOperations;
+  filename?: string;
+}
+
+const formatUrl = (
+  {
+    host,
+    uuid,
+    operations = {},
+    filename,
+  }: UploadcareParams,
+): string => {
+  const operationString = Object.entries(operations).map(
+    ([key, value]) => `${key}/${value}`,
+  ).join("/-/");
+
+  const pathSegments = [
+    host,
+    uuid,
+    operationString ? `-/${operationString}` : "",
+    filename,
+  ].join("/");
+
+  return `https://${pathSegments}`;
+};
+
+export const parse: UrlParser<UploadcareParams> = (imageUrl) => {
+  const url = toUrl(imageUrl);
+  const matchers = [...url.toString().matchAll(uploadcareRegex)];
+  if (!matchers.length) {
+    throw new Error("Invalid Uploadcare URL");
+  }
+
+  const group = matchers[0].groups || {};
+  const { ...baseParams } = group;
+
+  const filename = extractFilename(url.toString());
+  const { format: f, ...operations } = parseOperations(
+    extractOperations(url.toString()),
+  );
+  const format = (f && f !== "auto") ? f : "auto";
+
+  const base = formatUrl({
+    ...baseParams,
+    filename: filename || undefined,
+    operations: {
+      ...operations,
+      format,
+    },
+  });
+
+  return {
+    base,
+    cdn: "uploadcare",
+    params: {
+      ...group,
+      filename: filename || undefined,
+      operations: {
+        ...operations,
+        format,
+      },
+    },
+  };
+};
+
+export const generate: UrlGenerator<UploadcareParams> = ({
+  base,
+  width,
+  height,
+  params,
+}) => {
+  const parsed = parse(base.toString());
+
+  const props: UploadcareParams = {
+    operations: {},
+    ...parsed.params,
+    ...params,
+  };
+
+  if (width && height) {
+    props.operations = {
+      ...props.operations,
+      resize: `${width}x${height}`,
+    };
+  } else {
+    if (width) {
+      props.operations = {
+        ...props.operations,
+        resize: `${width}x`,
+      };
+    }
+
+    if (height) {
+      props.operations = {
+        ...props.operations,
+        resize: `x${height}`,
+      };
+    }
+  }
+
+  return formatUrl(props);
+};
+
+export const transform: UrlTransformer = ({
+  url: originalUrl,
+  width,
+  height,
+}) => {
+  const parsed = parse(originalUrl);
+  if (!parsed) {
+    throw new Error("Invalid Uploadcare URL");
+  }
+
+  const props: UrlGeneratorOptions<UploadcareParams> = {
+    ...parsed,
+    width,
+    height,
+  };
+
+  return generate(props);
+};

--- a/src/transformers/uploadcare.ts
+++ b/src/transformers/uploadcare.ts
@@ -359,7 +359,8 @@ export const generate: UrlGenerator<UploadcareParams> = ({
   height,
   params,
 }) => {
-  const parsed = parse(base.toString());
+  const baseUrl = base.toString();
+  const parsed = parse(baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`);
 
   const props: UploadcareParams = {
     operations: {},

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,7 @@ export type ImageCdn =
   | "ipx"
   | "astro"
   | "netlify"
-  | "imagekit";
+  | "imagekit"
+  | "uploadcare";
 
 export type SupportedImageCdn = ImageCdn;


### PR DESCRIPTION
closes #18 

This one was more difficult than I though because some operations of the URL can accept one or two values separated by a `/`, after digging around I found `@uploadcare/blocks`; inside their utils they have the functions to parse correctly the operations and filename from the URL if is provided, I give the credit to them in a comment and added a URL to the specific lines