### PR TITLE
feat: add Supabase support

### DIFF
--- a/data/subdomains.json
+++ b/data/subdomains.json
@@ -9,5 +9,6 @@
   "imgeng.in": "imageengine",
   "imagekit.io": "imagekit",
   "cloudimg.io": "cloudimage",
-  "ucarecdn.com": "uploadcare"
+  "ucarecdn.com": "uploadcare",
+  "supabase.co": "supabase"
 }

--- a/demo/src/examples.json
+++ b/demo/src/examples.json
@@ -79,5 +79,9 @@
   "uploadcare": [
     "Uploadcare",
     "https://ucarecdn.com/661bd414-064c-477a-b50f-8ffd8f66aa49/"
+  ],
+  "supabase": [
+    "Supabase",
+    "https://yowqvxclgkqcewrmwzzv.supabase.co/storage/v1/object/public/test/unpic.avif"
   ]
 }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -23,6 +23,7 @@ import { parse as astro } from "./transformers/astro.ts";
 import { parse as netlify } from "./transformers/netlify.ts";
 import { parse as imagekit } from "./transformers/imagekit.ts";
 import { parse as uploadcare } from "./transformers/uploadcare.ts";
+import { parse as supabase } from "./transformers/supabase.ts";
 import { ImageCdn, ParsedUrl, SupportedImageCdn, UrlParser } from "./types.ts";
 
 export const parsers = {
@@ -50,6 +51,7 @@ export const parsers = {
   netlify,
   imagekit,
   uploadcare,
+  supabase,
 };
 
 export const cdnIsSupportedForParse = (

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -23,6 +23,7 @@ import { transform as astro } from "./transformers/astro.ts";
 import { transform as netlify } from "./transformers/netlify.ts";
 import { transform as imagekit } from "./transformers/imagekit.ts";
 import { transform as uploadcare } from "./transformers/uploadcare.ts";
+import { transform as supabase } from "./transformers/supabase.ts";
 import { ImageCdn, UrlTransformer } from "./types.ts";
 import { getCanonicalCdnForUrl } from "./canonical.ts";
 
@@ -51,6 +52,7 @@ export const getTransformer = (cdn: ImageCdn) => ({
   netlify,
   imagekit,
   uploadcare,
+  supabase,
 }[cdn]);
 
 /**

--- a/src/transformers/supabase.test.ts
+++ b/src/transformers/supabase.test.ts
@@ -1,0 +1,80 @@
+import { assertEquals } from "https://deno.land/std@0.172.0/testing/asserts.ts";
+
+import { transform } from "./supabase.ts";
+
+const img =
+  "https://yowqvxclgkqcewrmwzzv.supabase.co/storage/v1/object/public/test/unpic.avif";
+
+Deno.test("supabase", async (t) => {
+  await t.step("should format a URL", () => {
+    const result = transform({
+      url: img,
+      width: 200,
+      height: 100,
+    });
+    assertEquals(
+      result?.toString(),
+      "https://yowqvxclgkqcewrmwzzv.supabase.co/storage/v1/object/public/test/unpic.avif?width=200&height=100&fit=fill",
+    );
+  });
+  await t.step("should not set height if not provided", () => {
+    const result = transform({ url: img, width: 200 });
+    assertEquals(
+      result?.toString(),
+      "https://yowqvxclgkqcewrmwzzv.supabase.co/storage/v1/object/public/test/unpic.avif?width=200&fit=fill",
+    );
+  });
+  await t.step("should delete height if not set", () => {
+    const url = new URL(img);
+    url.searchParams.set("height", "100");
+    const result = transform({ url, width: 200 });
+    assertEquals(
+      result?.toString(),
+      "https://yowqvxclgkqcewrmwzzv.supabase.co/storage/v1/object/public/test/unpic.avif?width=200&fit=fill",
+    );
+  });
+
+  await t.step("should round non-integer params", () => {
+    const result = transform({
+      url: img,
+      width: 200.6,
+      height: 100.2,
+    });
+    assertEquals(
+      result?.toString(),
+      "https://yowqvxclgkqcewrmwzzv.supabase.co/storage/v1/object/public/test/unpic.avif?width=201&height=100&fit=fill",
+    );
+  });
+
+  await t.step("should not set resize=crop if another value exists", () => {
+    const url = new URL(img);
+    url.searchParams.set("resize", "fill");
+    const result = transform({ url, width: 200, height: 100 });
+    assertEquals(
+      result?.toString(),
+      "https://yowqvxclgkqcewrmwzzv.supabase.co/storage/v1/object/public/test/unpic.avif?resize=fill&width=200&height=100&fit=fill",
+    );
+  });
+
+  await t.step("should not set auto=webp if format is set", () => {
+    const url = new URL(img);
+    url.searchParams.set("format", "png");
+    const result = transform({ url, width: 200, height: 100 });
+    assertEquals(
+      result?.toString(),
+      "https://yowqvxclgkqcewrmwzzv.supabase.co/storage/v1/object/public/test/unpic.avif?format=png&width=200&height=100&fit=fill",
+    );
+  });
+
+  await t.step(
+    "should not set fit if width and height are not both set",
+    () => {
+      const url = new URL(img);
+      const result = transform({ url, width: 100 });
+      assertEquals(
+        result?.toString(),
+        "https://yowqvxclgkqcewrmwzzv.supabase.co/storage/v1/object/public/test/unpic.avif?width=100&fit=fill",
+      );
+    },
+  );
+});

--- a/src/transformers/supabase.ts
+++ b/src/transformers/supabase.ts
@@ -1,0 +1,57 @@
+import { UrlParser, UrlTransformer } from "../types.ts";
+import {
+  getNumericParam,
+  setParamIfDefined,
+  setParamIfUndefined,
+  toUrl,
+} from "../utils.ts";
+
+export const parse: UrlParser<{
+  /**
+   * @see https://supabase.com/docs/guides/storage/serving/image-transformations#modes
+   */
+  resize?: string;
+}> = (url) => {
+  const parsedUrl = toUrl(url);
+
+  const resize = parsedUrl.searchParams.get("resize") || undefined;
+  const width = getNumericParam(parsedUrl, "width");
+  const height = getNumericParam(parsedUrl, "height");
+  const quality = getNumericParam(parsedUrl, "quality");
+  const format = parsedUrl.searchParams.get("format") || undefined;
+  parsedUrl.search = "";
+
+  return {
+    width,
+    height,
+    format,
+    base: parsedUrl.toString(),
+    params: { resize, quality },
+    cdn: "supabase",
+  };
+};
+
+export const transform: UrlTransformer = (
+  { url: originalUrl, width, height, format },
+) => {
+  const url = toUrl(originalUrl);
+  if (width && width > 2500) {
+    if (height) {
+      height = Math.round(height * 2500 / width);
+    }
+    width = 2500;
+  }
+
+  if (height && height > 2500) {
+    if (width) {
+      width = Math.round(width * 2500 / height);
+    }
+    height = 2500;
+  }
+
+  setParamIfDefined(url, "width", width, true, true);
+  setParamIfDefined(url, "height", height, true, true);
+  setParamIfDefined(url, "format", format);
+  setParamIfUndefined(url, "fit", "fill");
+  return url;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,7 @@ export type ImageCdn =
   | "astro"
   | "netlify"
   | "imagekit"
-  | "uploadcare";
+  | "uploadcare"
+  | "supabase";
 
 export type SupportedImageCdn = ImageCdn;


### PR DESCRIPTION
Since Supabase has a basic image transformation, this `transform` function passes all the params and also works with the limit of `2500px` per image that Supabase has