### PR TITLE
fix: hygraph assets urls can have capital letters

### DIFF
--- a/src/transformers/hygraph.ts
+++ b/src/transformers/hygraph.ts
@@ -6,7 +6,7 @@ import {
 } from "../types.ts";
 
 const hygraphRegex =
-	/https:\/\/(?<region>[a-z0-9-]+)\.graphassets\.com\/(?<envId>[a-z0-9]+)(?:\/(?<transformations>.*?))?\/(?<handle>[a-z0-9]+)$/;
+	/https:\/\/(?<region>[a-z0-9-]+)\.graphassets\.com\/(?<envId>[a-zA-Z0-9]+)(?:\/(?<transformations>.*?))?\/(?<handle>[a-zA-Z0-9]+)$/;
 
 export interface HygraphParams {
 	region?: string;


### PR DESCRIPTION
Hygraph now allows uppercase letters in their env and asset ids