### PR TITLE
fix: Update imagekit crop options and add crop mode

### DIFF
--- a/src/providers/imagekit.test.ts
+++ b/src/providers/imagekit.test.ts
@@ -130,7 +130,8 @@ Deno.test("imagekit generate", async (t) => {
 			const result = generate(img, {
 				w: 400,
 				h: 300,
-				c: "pad_resize",
+				cm: "pad_resize",
+				c: "at_max_enlarge",
 				fo: "bottom",
 				bg: "FFFFFF",
 				r: 90,
@@ -138,7 +139,7 @@ Deno.test("imagekit generate", async (t) => {
 			});
 			assertEqualIgnoringQueryOrder(
 				result,
-				`${img}?tr=w-400,h-300,c-pad_resize,fo-bottom,bg-FFFFFF,r-90,q-85`,
+				`${img}?tr=w-400,h-300,cm-pad_resize,c-at_max_enlarge,fo-bottom,bg-FFFFFF,r-90,q-85`,
 			);
 		},
 	);

--- a/src/providers/imagekit.ts
+++ b/src/providers/imagekit.ts
@@ -32,15 +32,23 @@ export interface ImageKitOperations extends Operations {
 
 	/**
 	 * Crop strategy for the image.
-	 * Options: 'maintain_ratio', 'extract', 'pad_resize', 'force', 'at_max', 'at_least'
+	 * Options: 'maintain_ratio', 'force', 'at_max', 'at_max_enlarge', 'at_least'
 	 */
 	c?:
 		| "maintain_ratio"
-		| "extract"
-		| "pad_resize"
 		| "force"
 		| "at_max"
+		| "at_max_enlarge"
 		| "at_least";
+
+	/**
+	 * Crop mode for the image.
+	 * Options: 'extract', 'pad_resize', 'pad_extract'
+	 */
+	cm?:
+		| "extract"
+		| "pad_resize"
+		| "pad_extract";
 
 	/**
 	 * Focal point for cropping. Can also pass object types for smart cropping.


### PR DESCRIPTION
According to the document at https://imagekit.io/docs/image-resize-and-crop#crop-crop-modes--focus
- `extract` and `pad_resize` are now prefixed with `cm-` instead of `c-`. It also have a new value `cm-pad_extract`
- Additionally, crop has a new value `c-at_max_enlarge`