### PR TITLE
fix: export utility functions

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -4,6 +4,7 @@
 	"exports": {
 		".": "./mod.ts",
 		"./async": "./src/async.ts",
+		"./utils": "./src/utils.ts",
 		"./providers/appwrite": "./src/providers/appwrite.ts",
 		"./providers/astro": "./src/providers/astro.ts",
 		"./providers/builder.io": "./src/providers/builder.io.ts",

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -36,6 +36,10 @@ await build({
 			path: "./src/transform.ts",
 			name: "./transform",
 		},
+		{
+			path: "./src/utils.ts",
+			name: "./utils",
+		},
 		...entry,
 	],
 	outDir: "./npm",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import type { ProviderOperations, ProviderOptions } from "./providers/types.ts";
-import {
-	type ImageCdn,
+import type {
+	ImageCdn,
 	OperationFormatter,
 	OperationMap,
 	OperationParser,


### PR DESCRIPTION
Export functions from '/utils'

Fixes #161