### PR TITLE
Fix: Make ipx transform work with a remote base url

### DIFF
--- a/src/providers/ipx.test.ts
+++ b/src/providers/ipx.test.ts
@@ -5,6 +5,8 @@ import { assertEquals } from "jsr:@std/assert";
 const absoluteImg = "https://example.com/images/test.jpg";
 const img = "/images/test.jpg";
 const baseURL = "https://example.com/_ipx";
+const remoteBaseUrl = "https://ipx.example.com";
+
 
 Deno.test("ipx extract", async (t) => {
 	await t.step("should extract operations from a URL", () => {
@@ -120,6 +122,21 @@ Deno.test("ipx transform", async (t) => {
 		assertEqualIgnoringQueryOrder(
 			result,
 			`/_ipx/s_300x200,f_auto/https://example.com/images/test.jpg`,
+		);
+	});
+
+	await t.step("should work with ipx as a remote service baseURL", () => {
+		const result = transform(
+			absoluteImg,
+			{
+				width: 300,
+				height: 200,
+			},
+			{ baseURL: remoteBaseUrl },
+		);
+		assertEqualIgnoringQueryOrder(
+			result,
+			`${remoteBaseUrl}/s_300x200,f_auto/https://example.com/images/test.jpg`,
 		);
 	});
 });

--- a/src/providers/ipx.ts
+++ b/src/providers/ipx.ts
@@ -74,7 +74,7 @@ export const generate: URLGenerator<"ipx"> = (
 	const baseURL = options?.baseURL ?? "/_ipx";
 	const url = toUrl(baseURL);
 
-	url.pathname = `${url.pathname}/${modifiers}/${
+	url.pathname = `${url.pathname === '/' ? '' : url.pathname}/${modifiers}/${
 		stripLeadingSlash(src.toString())
 	}`;
 	return toCanonicalUrlString(url);


### PR DESCRIPTION
I'm building a project with a specific service for my images with ipx and satori for og images with a remote base URL: https://img.example.com.

There was a problem with a double // 

<img width="850" height="165" alt="image" src="https://github.com/user-attachments/assets/8cf52dbb-c139-4585-a6af-a6ea2fe5c295" />

So I decided to fix it with a test. It should works well with this now
