### PR TITLE
fix(imgix): types for combined 'auto' operations

### DIFF
--- a/src/providers/imgix.ts
+++ b/src/providers/imgix.ts
@@ -12,6 +12,8 @@ import {
 	toUrl,
 } from "../utils.ts";
 
+type Auto = "true" | "format" | "compress" | "enhance" | "redeye";
+
 export type ImixFormats =
 	| ImageFormat
 	| "gif"
@@ -76,10 +78,15 @@ export interface ImgixOperations extends Operations<ImixFormats> {
 
 	/**
 	 * Automatic optimizations to apply.
-	 * Can be a combination of "format", "compress", "enhance", "redeye".
+	 * Can be a combination of "format", "compress", "enhance", "redeye", "true".
 	 * @example "format,compress"
 	 */
-	auto?: "format" | "compress" | "enhance" | "redeye";
+	auto?:
+		| Auto
+		| `${Auto},${Auto}`
+		| `${Auto},${Auto},${Auto}`
+		| `${Auto},${Auto},${Auto},${Auto}`
+		| `${Auto},${Auto},${Auto},${Auto},${Auto}`;
 
 	/**
 	 * Contrast adjustment (-100 to 100).


### PR DESCRIPTION
In Imgix, the type for `auto` is incorrect. As the doc comment says, it can be a combination of values https://github.com/ascorbic/unpic/blob/482ca8fa9379a66fcb4e0cc1fc610382ae7417a7/src/providers/imgix.ts#L80

All combinations are permitted in this PR, including some which are nonsensical but still valid `format,format,format,format`. However, these are still valid imgix URLs.

One complication might be this line:
https://github.com/ascorbic/unpic/blob/482ca8fa9379a66fcb4e0cc1fc610382ae7417a7/src/providers/imgix.ts#L238

Imgix has its [own logic](https://docs.imgix.com/en-US/apis/rendering/automatic#format) to handle `auto=format` and `fm=`, which unpic overrides above. Should I update this to handle cases like `auto=compress,format` as well, or is it OK to fall back to Imgix's handling?